### PR TITLE
Issue #1: Add basic tox setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 prettytable
 python-dateutil
+tox

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/aashutoshrathi/git-stalk-cli",
     packages=setuptools.find_packages(),
-    install_requires=['requests','prettytable', 'python-dateutil'],
+    install_requires=['requests','prettytable', 'python-dateutil', 'tox'],
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py36
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest


### PR DESCRIPTION
Add basic setup for tox, closes #1 
Currently run tests for Python 2.7 and 3.6