### PR TITLE
 Add --date argument - closes #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+.tox
+.pytest_cache


### PR DESCRIPTION
If `--date` argument is passed, the script will filter from all
events the ones that were created in the selected date.

If no `--date` argument is passed, only today events are shown.

Also add a pagination logic to fetch all results from Github API.