### PR TITLE
showing help while running without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 2018-10-25
+
+### Bug Fixes
+
+- Fixed the application call with no arguments, now showing help by @rods-honorio 
+
 ## [1.2.0] - 2018-10-23
 
 ### Added

--- a/git_stalk/stalk.py
+++ b/git_stalk/stalk.py
@@ -3,6 +3,7 @@ import argparse
 import datetime
 import os
 import re
+import sys
 from collections import namedtuple
 import requests
 from dateutil import tz
@@ -340,7 +341,7 @@ def run():
         help=(
             "Take into account only events until date. Date format MM-DD-YYYY")
     )
-    args = vars(ap.parse_args())
+    args = vars(ap.parse_args(args=None if sys.argv[1:] else ['--help']))
 
     if len(args) > 1:
         if args["update"]:


### PR DESCRIPTION
fixing the issue to showing the help information if the application is called with no arguments